### PR TITLE
Revertir en site HTML statique

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,47 +1,36 @@
-# Vlada BOCHE – Coach de Vie | Page de contact
+# Vlada BOCHE – Coach de Vie
 
-Ce dépôt contient le site de contact officiel de **Vlada BOCHE**, coach de vie spécialisée en accompagnement et reconversion professionnelle.
+Ce dépôt contient le site officiel **www.vlada.fr** de Vlada Boche, coach professionnelle spécialisée en reconversion et développement personnel. Le site est entièrement réalisé en **HTML** et **CSS** pour garantir un chargement rapide et une compatibilité maximale.
 
 ## Présentation
 
-Ce site web offre un accès rapide et sécurisé aux moyens de contacter Vlada Boche et de suivre son actualité sur les réseaux sociaux professionnels.
+Le site présente la méthode de coaching de Vlada, son parcours et les moyens de la contacter.
 
 ### Fonctionnalités principales
 
-- Informations de contact direct (email, téléphone, WhatsApp)
-- Liens vers les réseaux sociaux (Facebook, Instagram, LinkedIn)
-- Design responsive adapté à tous les supports
-- Navigation claire et intuitive
-
-## Technologies utilisées
-
-- **HTML5**
-- **CSS3**
-- **Font Awesome** (pour les icônes)
+- Description complète de l'activité et du parcours de Vlada
+- Section "À propos" détaillant les formations et certifications
+- Liste de services et approche méthodologique
+- Témoignages de clients
+- Coordonnées directes (email, téléphone, WhatsApp)
+- Formulaire de contact
+- Liens vers les réseaux sociaux (Facebook, Instagram, LinkedIn, TikTok, FIDE)
+- Design responsive et navigation claire entre l'accueil et la page de contact
 
 ## Structure du projet
 
-- `index.html` — Page principale
-- `styles.css` — Feuille de style personnalisée
-- `assets/images/` — Images (photo de profil, favicon…)
+- `index.html` – Page d'accueil
+- `contact.html` – Page de contact
+- `style.css` – Feuille de style principale
+- `images/` – Images utilisées (photo de profil, favicon)
 
-## Confidentialité
+## Biographie de Vlada Boche
 
-La protection de vos données personnelles est une priorité.  
-Aucune donnée personnelle n’est collectée automatiquement via ce site.  
-Les informations de contact (email, téléphone, WhatsApp) sont uniquement fournies pour permettre à l’utilisateur de joindre directement Vlada Boche.  
-Aucune information n’est transmise à des tiers. Les échanges restent strictement confidentiels.
+Vlada Boche est diplômée d'État en psychologie en Ukraine et certifiée en Programmation Neuro‑Linguistique par l'IFPNL. Elle s'est formée à l'orientation scolaire (méthode SISEM) et au bilan de compétences (Repère). Basée à Montrouge (Île‑de‑France), elle accompagne depuis plus de cinq ans les personnes en reconversion professionnelle ou en quête de développement personnel. Ses séances se déroulent en présentiel ou à distance, avec une première consultation à 57 € puis un tarif normal de 80 €.
 
-## Installation & utilisation
+## Utilisation
 
-1. Cloner le dépôt ou télécharger les fichiers.
-2. Ouvrir `index.html` dans un navigateur web.
-
-Aucune configuration spécifique n’est requise.
-
-## Déploiement
-
-Le site peut être hébergé sur toute plateforme statique (GitHub Pages, Netlify, Vercel…).
+Ouvrez simplement `index.html` dans votre navigateur favori pour consulter le site en local.
 
 ## Auteur
 
@@ -51,17 +40,11 @@ Développé par **Mathis Boche** pour le compte de Vlada Boche.
 
 ## Contact professionnel
 
-- **Email :** vlada.boche@yahoo.fr  
-- **Téléphone :** +33 6 18 68 88 43
+- **Email :** vlada.boche@yahoo.fr
+- **Téléphone :** +33 6 18 68 88 43
 
 ---
 
 ## Disclaimer
 
-Ce site est une page de contact informative à destination des clients et partenaires potentiels de Vlada Boche.  
-Toutes les informations présentes sont fournies à titre indicatif et peuvent évoluer.  
-L’utilisation des coordonnées fournies est strictement réservée à des prises de contact professionnelles ou personnelles en lien avec l’activité de coaching.  
-Toute utilisation non autorisée ou diffusion à des fins commerciales, publicitaires ou de démarchage est interdite.
-
----
-
+Toutes les informations présentes sont fournies à titre indicatif et peuvent évoluer. L’utilisation des coordonnées est réservée aux prises de contact en lien avec l’activité de coaching. Toute diffusion commerciale non autorisée est interdite.

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Contact - Vlada BOCHE</title>
+  <link rel="stylesheet" href="style.css">
+  <link rel="icon" href="images/favicon.ico">
+  <script src="https://kit.fontawesome.com/a1516d132b.js" crossorigin="anonymous"></script>
+</head>
+<body>
+  <header>
+    <img src="images/vb.jpg" alt="Vlada BOCHE" class="profile-img" width="150" height="150">
+    <h1>Vlada BOCHE</h1>
+    <h2>Coach de Vie</h2>
+    <h3 class="sous-titre">Coach de reconversion</h3>
+    <nav class="navbar">
+      <ul>
+        <li><a href="index.html">Accueil</a></li>
+        <li><a class="active" href="contact.html">Contact</a></li>
+      </ul>
+    </nav>
+  </header>
+  <main>
+    <section id="contact">
+      <h2>Contact</h2>
+      <p>Pour plus d'informations ou pour réserver une session, veuillez me contacter :</p>
+      <p><i class="fa-solid fa-envelope"></i> <strong>Email :</strong> <a href="mailto:vlada.boche@yahoo.fr">vlada.boche@yahoo.fr</a></p>
+      <p><i class="fa-solid fa-phone"></i> <strong>Téléphone :</strong> <a href="tel:+33618688843">+33 6 18 68 88 43</a></p>
+      <p><i class="fa-brands fa-whatsapp"></i> <strong>WhatsApp :</strong> <a href="https://wa.me/33664443538?text=Bonjour%20Vlada%2C%20j'aimerais%20en%20savoir%20plus%20sur%20vos%20services." target="_blank" rel="noopener noreferrer">Cliquez ici</a></p>
+    </section>
+    <section id="infos">
+      <h2>Informations pratiques</h2>
+      <p><i class="fa-solid fa-location-dot"></i> 202 Avenue Marx Dormoy, 92120 Montrouge. Séances en présentiel ou à distance.</p>
+      <p><i class="fa-solid fa-clock"></i> Disponibilités du lundi au vendredi, de 9h à 18h.</p>
+      <p><i class="fa-solid fa-euro-sign"></i> Première séance 57&nbsp;€, tarif normal 80&nbsp;€.</p>
+    </section>
+    <section id="formulaire">
+      <h2>Envoyer un message</h2>
+      <form>
+        <label for="nom">Nom</label>
+        <input type="text" id="nom" name="nom" required>
+        <label for="email">Email</label>
+        <input type="email" id="email" name="email" required>
+        <label for="message">Message</label>
+        <textarea id="message" name="message" rows="5" required></textarea>
+        <button type="submit">Envoyer</button>
+      </form>
+    </section>
+    <section id="reseaux">
+      <h2>Réseaux Sociaux</h2>
+      <p>Suivez-moi sur :</p>
+      <p><i class="fa-brands fa-facebook-f"></i><a href="https://www.facebook.com/profile.php?id=100009659551709" target="_blank" rel="noopener noreferrer">Facebook</a></p>
+      <p><i class="fa-brands fa-instagram"></i><a href="https://www.instagram.com/vlada.boche/" target="_blank" rel="noopener noreferrer">Instagram</a></p>
+      <p><i class="fa-brands fa-linkedin-in"></i><a href="https://www.linkedin.com/in/vlada-boche/?originalSubdomain=fr" target="_blank" rel="noopener noreferrer">LinkedIn</a></p>
+    </section>
+  </main>
+  <footer>
+    <p>&copy; 2025 Vlada BOCHE. Tous droits réservés.</p>
+  </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,87 +1,69 @@
 <!DOCTYPE html>
 <html lang="fr">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>Contact - Vlada BOCHE, Coach de Vie</title>
-
-  <!-- Favicon -->
-  <link rel="icon" href="/images/favicon.ico" type="image/x-icon"/>
-
-  <!-- Feuille de style principale -->
-  <link rel="stylesheet" href="styles.css" />
-
-  <!-- Import de Font Awesome (version 6.x par exemple) -->
-  <script src="https://kit.fontawesome.com/059bae2efb.js" crossorigin="anonymous"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Vlada BOCHE - Coach de Vie</title>
+  <link rel="stylesheet" href="style.css">
+  <link rel="icon" href="images/favicon.ico">
+  <script src="https://kit.fontawesome.com/a1516d132b.js" crossorigin="anonymous"></script>
 </head>
 <body>
-  <!-- En-tête du site -->
   <header>
-    <img src="images/vb.jpg" alt="Vlada BOCHE" class="profile-img"/>
+    <img src="images/vb.jpg" alt="Vlada BOCHE" class="profile-img" width="150" height="150">
     <h1>Vlada BOCHE</h1>
     <h2>Coach de Vie</h2>
     <h3 class="sous-titre">Coach de reconversion</h3>
+    <nav class="navbar">
+      <ul>
+        <li><a class="active" href="index.html">Accueil</a></li>
+        <li><a href="contact.html">Contact</a></li>
+      </ul>
+    </nav>
   </header>
-
-  <!-- Contenu principal -->
   <main>
-    <!-- Section de contact direct -->
-    <section id="contact">
-      <h2>Contact</h2>
-      <p>Pour plus d'informations ou pour réserver une session, veuillez me contacter :</p>
-
-      <!-- Email -->
-      <p>
-        <i class="fa-solid fa-envelope"></i>
-        <strong>Email :</strong>
-        <a href="mailto:vlada.boche@yahoo.fr">vlada.boche@yahoo.fr</a>
-      </p>
-      <!-- Téléphone -->
-      <p>
-        <i class="fa-solid fa-phone"></i>
-        <strong>Téléphone :</strong>
-        <a href="tel:+33618688843">+33 6 18 68 88 43</a>
-      </p>
-      <!-- WhatsApp -->
-      <p>
-        <i class="fa-brands fa-whatsapp"></i>
-        <strong>WhatsApp :</strong>
-        <a 
-          href="https://wa.me/33664443538?text=Bonjour%20Vlada%2C%20j%27aimerais%20en%20savoir%20plus%20sur%20vos%20services."
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Cliquez ici
-        </a>
-      </p>
+    <section id="presentation">
+      <h2>Bienvenue</h2>
+      <p>Je vous accompagne dans votre évolution professionnelle et personnelle pour atteindre vos objectifs et révéler votre potentiel.</p>
+      <p class="cta"><a class="button" href="contact.html">Prendre rendez-vous</a></p>
     </section>
-
-    <!-- Section Réseaux Sociaux -->
+    <section id="about">
+      <h2>À propos de Vlada</h2>
+      <p>Diplômée d'État en psychologie en Ukraine et certifiée en Programmation Neuro‑Linguistique (IFPNL), j’accompagne depuis plus de cinq ans les personnes en quête d'épanouissement professionnel et personnel.</p>
+      <p>Je suis également formée à l’orientation scolaire (SISEM) et aux bilans de compétences (Repère).</p>
+      <p>Basée à Montrouge, je propose des séances en présentiel ou à distance afin de m'adapter à votre rythme.</p>
+    </section>
+    <section id="services">
+      <h2>Mes services</h2>
+      <ul class="services-list">
+        <li>Coaching de reconversion professionnelle</li>
+        <li>Orientation scolaire et professionnelle</li>
+        <li>Bilan de compétences</li>
+        <li>Ateliers de développement personnel</li>
+        <li>Accompagnement en cas de deuil, rupture ou burn-out</li>
+        <li>Suivi personnalisé et bienveillant</li>
+      </ul>
+    </section>
+    <section id="approche">
+      <h2>Mon approche</h2>
+      <p>J'utilise des méthodes reconnues de coaching, une écoute active et des outils de développement personnel pour vous guider pas à pas.</p>
+      <p>Chaque accompagnement est unique afin de lever vos blocages et atteindre vos objectifs.</p>
+    </section>
+    <section id="temoignages">
+      <h2>Témoignages</h2>
+      <blockquote>« Grâce à l'accompagnement de Vlada, j'ai pu changer de voie et retrouver confiance en moi. » — Marie</blockquote>
+      <blockquote>« Une coach à l'écoute qui sait poser les bonnes questions pour avancer. » — Julien</blockquote>
+    </section>
     <section id="reseaux">
       <h2>Réseaux Sociaux</h2>
       <p>Suivez-moi sur :</p>
-      <p>
-        <i class="fa-brands fa-facebook-f"></i>
-        <a href="https://www.facebook.com/profile.php?id=100009659551709" target="_blank" rel="noopener noreferrer">
-          Facebook
-        </a>
-      </p>
-      <p>
-        <i class="fa-brands fa-instagram"></i>
-        <a href="https://www.instagram.com/vlada.boche/" target="_blank" rel="noopener noreferrer">
-          Instagram
-        </a>
-      </p>
-      <p>
-        <i class="fa-brands fa-linkedin-in"></i>
-        <a href="https://www.linkedin.com/in/vlada-boche/?originalSubdomain=fr" target="_blank" rel="noopener noreferrer">
-          LinkedIn
-        </a>
-      </p>
+      <p><i class="fa-brands fa-facebook-f"></i><a href="https://www.facebook.com/profile.php?id=100009659551709" target="_blank" rel="noopener noreferrer">Facebook</a></p>
+      <p><i class="fa-brands fa-instagram"></i><a href="https://www.instagram.com/vlada.boche/" target="_blank" rel="noopener noreferrer">Instagram</a></p>
+      <p><i class="fa-brands fa-tiktok"></i><a href="https://www.tiktok.com/@vlada.kochh" target="_blank" rel="noopener noreferrer">TikTok</a></p>
+      <p><i class="fa-brands fa-linkedin-in"></i><a href="https://www.linkedin.com/in/vlada-boche/?originalSubdomain=fr" target="_blank" rel="noopener noreferrer">LinkedIn</a></p>
+      <p><i class="fa-solid fa-chess"></i><a href="https://ratings.fide.com/profile/651010780" target="_blank" rel="noopener noreferrer">Profil FIDE</a></p>
     </section>
   </main>
-
-  <!-- Pied de page -->
   <footer>
     <p>&copy; 2025 Vlada BOCHE. Tous droits réservés.</p>
   </footer>

--- a/style.css
+++ b/style.css
@@ -57,6 +57,27 @@ header h2 {
     color: #a2d5f2; /* bleu clair */
 }
 
+/* Navigation principale */
+nav ul {
+    list-style: none;
+    margin-top: 1rem;
+    display: flex;
+    justify-content: center;
+    gap: 2rem;
+}
+
+nav a {
+    color: #fff;
+    text-decoration: none;
+    font-weight: 600;
+    padding: 0.25rem 0;
+}
+
+nav a:hover,
+nav a.active {
+    border-bottom: 2px solid #a2d5f2;
+}
+
 /* Exemple de style minimal pour le nouveau sous-titre */
 .sous-titre {
     /* Pas de bordure et ajustement éventuel du style */
@@ -81,6 +102,14 @@ section {
     margin-bottom: 3rem;
 }
 
+.services-list {
+    list-style: disc;
+    margin: 0 auto;
+    padding-left: 1.5rem;
+    max-width: 600px;
+    text-align: left;
+}
+
 /* Titres de section */
 h2 {
     color: #2a4d69;
@@ -96,6 +125,34 @@ h2 {
 p {
     margin: 1rem 0;
     font-size: 1.125rem;
+}
+
+.cta {
+    text-align: center;
+}
+
+.button {
+    background-color: #2a4d69;
+    color: #fff;
+    padding: 0.75rem 1.5rem;
+    border-radius: 5px;
+    text-decoration: none;
+    font-weight: bold;
+    display: inline-block;
+    transition: background-color 0.3s;
+}
+
+.button:hover {
+    background-color: #1e3a57;
+}
+/* Style pour les témoignages */
+blockquote {
+    max-width: 600px;
+    margin: 1rem auto;
+    padding-left: 1rem;
+    border-left: 4px solid #a2d5f2;
+    font-style: italic;
+    color: #555;
 }
 
 /* ----------------------------------------------------
@@ -114,7 +171,8 @@ p {
 }
 
 /* Petit ajustement pour les icônes dans #contact */
-#contact i {
+#contact i,
+#infos i {
     margin-right: 0.5rem;
     color: #2a4d69;
 }


### PR DESCRIPTION
## Summary
- retirer l'architecture Next.js et revenir à un site entièrement HTML et CSS
- recréer `index.html` et `contact.html` avec une mise en page moderne
- déplacer les images dans `images/` et renommer la feuille de style en `style.css`
- mettre à jour le README avec la nouvelle structure

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848533e29588332a346aa7e68d473af